### PR TITLE
Fix permissions for OpenShift

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -6,7 +6,8 @@ RUN apk --no-cache add py3-pip py3-cryptography py3-mysqlclient curl && \
     pip3 install --upgrade pip && \
     pip3 install flask flask_sqlalchemy prometheus_flask_exporter --no-cache-dir && \
     adduser -D web && \
-    chown web /app 
+    chown -R web:root /app && \
+    chmod -R 2775 /app
 
 WORKDIR /app
 


### PR DESCRIPTION
Sets permissions so the non-privileged user inside the container executing the app still has the permissions to create the sqlite file.

Tested on OpenShift 4 and Rancher (temporary image `example-web-python:openshift`).