### PR TITLE
Add github actions to build images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,77 @@
+name: Build and push image
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to Quay.io Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAYIO_USERNAME }}
+          password: ${{ secrets.QUAYIO_TOKEN }}
+      -
+        name: Build go app image
+        uses: docker/build-push-action@v2
+        with:
+          context: go
+          push: true
+          tags: |
+            quay.io/acend/example-web-go:pr-${{ github.event.pull_request.number }}
+      -
+        name: Run vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'quay.io/acend/example-web-go:pr-${{ github.event.pull_request.number }}'
+          format: 'table'
+          output: 'trivy-results.txt'
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: 'os'
+          severity: 'CRITICAL,HIGH'
+      -
+        name: Archive vulnerability scan results
+        uses: actions/upload-artifact@v2
+        with:
+          name: trivy-results-main
+          path: trivy-results.txt
+      -
+        name: Build python app image
+        uses: docker/build-push-action@v2
+        with:
+          context: python
+          push: true
+          tags: |
+            quay.io/acend/example-web-python:pr-${{ github.event.pull_request.number }}
+      -
+        name: Run vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'quay.io/acend/example-web-python:pr-${{ github.event.pull_request.number }}'
+          format: 'table'
+          output: 'trivy-results.txt'
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: 'os'
+          severity: 'CRITICAL,HIGH'
+      -
+        name: Archive vulnerability scan results
+        uses: actions/upload-artifact@v2
+        with:
+          name: trivy-results-main
+          path: trivy-results.txt

--- a/.github/workflows/pr-cleanup.yaml
+++ b/.github/workflows/pr-cleanup.yaml
@@ -1,0 +1,22 @@
+name: PR cleanup
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  deployment:
+    runs-on: 'ubuntu-latest'
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      -
+        name: Delete tags on Quay
+        id: delete_tags
+        env:
+          PR_NUMBER: '${{ github.event.pull_request.number }}'
+          QUAYIO_API_TOKEN: '${{ secrets.QUAYIO_API_TOKEN }}'
+        run: |
+          curl -X DELETE -H "Authorization: Bearer ${QUAYIO_API_TOKEN}" https://quay.io/api/v1/repository/example-web-{go,python}/tag/pr-${PR_NUMBER}

--- a/.github/workflows/push-main.yaml
+++ b/.github/workflows/push-main.yaml
@@ -34,7 +34,7 @@ jobs:
           context: go
           push: true
           tags: |
-            quay.io/acend/example-web-go:pr-${{ github.event.pull_request.number }}
+            quay.io/acend/example-web-go:latest
       -
         name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -59,7 +59,7 @@ jobs:
           context: python
           push: true
           tags: |
-            quay.io/acend/example-web-python:pr-${{ github.event.pull_request.number }}
+            quay.io/acend/example-web-python:latest
       -
         name: Run vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/push-main.yaml
+++ b/.github/workflows/push-main.yaml
@@ -1,0 +1,79 @@
+name: Publish Main Version
+
+on:
+  push:
+    branches:
+      - main
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - 
+        name: Login to Quay.io Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAYIO_USERNAME }}
+          password: ${{ secrets.QUAYIO_TOKEN }}
+      -
+        name: Build go app image
+        uses: docker/build-push-action@v2
+        with:
+          context: go
+          push: true
+          tags: |
+            quay.io/acend/example-web-go:pr-${{ github.event.pull_request.number }}
+      -
+        name: Run vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'quay.io/acend/example-web-go:latest'
+          format: 'table'
+          output: 'trivy-results.txt'
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: 'os'
+          severity: 'CRITICAL,HIGH'
+      -
+        name: Archive vulnerability scan results
+        uses: actions/upload-artifact@v2
+        with:
+          name: trivy-results-main
+          path: trivy-results.txt
+      -
+        name: Build python app image
+        uses: docker/build-push-action@v2
+        with:
+          context: python
+          push: true
+          tags: |
+            quay.io/acend/example-web-python:pr-${{ github.event.pull_request.number }}
+      -
+        name: Run vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'quay.io/acend/example-web-python:latest'
+          format: 'table'
+          output: 'trivy-results.txt'
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: 'os'
+          severity: 'CRITICAL,HIGH'
+      -
+        name: Archive vulnerability scan results
+        uses: actions/upload-artifact@v2
+        with:
+          name: trivy-results-main
+          path: trivy-results.txt


### PR DESCRIPTION
Quay.io currently can't build the image because of Docker Hub's pull rate limit. Using GitHub actions to build the image we can circumvent this.